### PR TITLE
Modify docker build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
             args:
                 GIT_TAG: ${GIT_TAG}
                 PORT_NUMBER: ${PORT_NUMBER}
-        image: pvws:${DOCKER_TAG}
+        image: gcr.io/diamond-privreg/pvws:${DOCKER_TAG}
         container_name: pvws 
         network_mode: "host"
         healthcheck:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git:latest as source_fetch
 
-RUN git clone https://github.com/ornl-epics/pvws.git /pvws
+RUN git clone https://github.com/DiamondLightSource/pvws.git /pvws
 ARG GIT_TAG=main
 RUN cd /pvws && git checkout ${GIT_TAG}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ FROM maven:3.8.7-eclipse-temurin-17 as maven_builder
 COPY --from=source_fetch /pvws /pvws
 RUN cd /pvws && mvn clean package 
 
-FROM tomcat:9.0-jdk17
+FROM tomcat:9.0-jdk17-corretto
 
 ARG PORT_NUMBER=8080
 COPY --from=maven_builder /pvws/target/pvws.war ${CATALINA_HOME}/webapps

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,22 @@
       <groupId>org.phoebus</groupId>
       <artifactId>core-pv</artifactId>
       <version>4.7.3</version>
+      <exclusions>
+        <exclusion>
+            <groupId>org.tango-controls</groupId>
+            <artifactId>JTango</artifactId>
+        </exclusion>
+      <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
+      </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.26.0</version>
     </dependency>
 
 <!-- To use a pre-release version of the latest core-pv and/or jca,


### PR DESCRIPTION
- Update tomcat image used in dockerfile
- Update pom.xml to remove tango dependency and use newer commons-compress version
Both of these changes have been made to reduce CVEs picked up by trivy