### PR TITLE
Fix CVEs in PVWS docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,3 +17,6 @@ COPY ./setenv.sh ${CATALINA_HOME}/bin
 RUN sed -i.bak -e "s|Connector port=\"8080\"|Connector port=\"${PORT_NUMBER}\"|g" \
   -e 's|Server port="8005" shutdown="SHUTDOWN"|Server port="-1" shutdown="SHUTDOWN"|g' \
    ${CATALINA_HOME}/conf/server.xml
+RUN sed -i s/1/0/ /etc/yum/pluginconf.d/priorities.conf
+RUN yum -y update java-17-amazon-corretto-devel
+ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64

--- a/pom.xml
+++ b/pom.xml
@@ -68,13 +68,13 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.13.2</version>
+      <version>2.16.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.2</version>
+      <version>2.16.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This PR fixes the CVEs reported in the built image reported by StackRox.
1. Update the java-corretto package when building the image to eliminate most of the CVEs.
2. Update the jackson-databind package in the PVWS build.