### PR TITLE
Add CI to build and push image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -51,13 +51,14 @@ jobs:
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
         with:
-          context: ./docker
+          context: .
+          file: ./docker/Dockerfile
           # Need load and tags so we can test it below
           load: true
           tags: tag_for_testing
 
       - name: Test cli works in cached runtime image
-        run: docker run --rm tag_for_testing --version
+        run: docker run docker.io/library/tag_for_testing --version
 
       - name: Create tags for publishing image
         id: meta

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -51,8 +51,7 @@ jobs:
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
         with:
-          context: .
-          file: ./docker/Dockerfile
+          context: ./docker
           # Need load and tags so we can test it below
           load: true
           tags: tag_for_testing

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -75,7 +75,7 @@ jobs:
         # This does not build the image again, it will find the image in the
         # Docker cache and publish it
         with:
-          context: .
+          context: ./docker
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,6 +55,7 @@ jobs:
           # Need load and tags so we can test it below
           load: true
           tags: tag_for_testing
+          network: host
 
       - name: Test cli works in cached runtime image
         run: docker run docker.io/library/tag_for_testing --version

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -57,9 +57,6 @@ jobs:
           tags: tag_for_testing
           network: host
 
-      - name: Test cli works in cached runtime image
-        run: docker run docker.io/library/tag_for_testing --version
-
       - name: Create tags for publishing image
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -56,6 +56,16 @@ jobs:
           load: true
           tags: tag_for_testing
           network: host
+      
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: 'docker.io/library/tag_for_testing:latest'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
 
       - name: Create tags for publishing image
         id: meta

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,15 +1,83 @@
 name: Docker Image CI
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  push: 
+  workflow_dispatch:
 
 jobs:
-  build:
+  build_container:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker compose build
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need this to get version number from last tag
+          fetch-depth: 0
+
+      - name: Validate SemVer2 version compliance
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          SEMVER_REGEX: ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$
+
+        run: |
+          ref="${{ github.ref_name }}"
+          my_regex="${{env.SEMVER_REGEX}}"
+          if [[ "$ref" =~ $my_regex ]]; then
+            echo "SemVer compliant version: $ref"
+          else
+            echo "Invalid SemVer version: $ref"
+            exit 1
+          fi
+
+      # Fetch latest tag on this branch if manually triggered
+      - name: Fetch latest tag
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "LATEST_TAG=$(git tag | sort --version-sort | tail -n1)" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Docker Registry
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and export to Docker local cache
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          context: ./docker
+          # Need load and tags so we can test it below
+          load: true
+          tags: tag_for_testing
+
+      - name: Test cli works in cached runtime image
+        run: docker run --rm tag_for_testing --version
+
+      - name: Create tags for publishing image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+            type=semver,pattern={{version}},value=${{ env.LATEST_TAG }},enable=${{github.event_name == 'workflow_dispatch'}}
+
+      - name: Push cached image to container registry
+        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        # This does not build the image again, it will find the image in the
+        # Docker cache and publish it
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I added CI that builds the image using docker. When a new tag is pushed the image is pushed to the container registry. This CI can also be triggered manually to push the image again with the last tag used.

Although there is a docker-compose.yml file in this repo, the CI uses docker github actions and the Dockerfile directly to build the image.